### PR TITLE
ci: skip "Get tag" when not building a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
 
       - name: Get tag
         id: tag
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: dawidd6/action-get-tag@12319896edaa290b27558e34a177804e9b8d077b # v1
         continue-on-error: true # empty steps.tag.outputs.tag will inform the next step
 


### PR DESCRIPTION
Remove the following warning print by GitHub Actions when building e.g. a pull request:

```
Run dawidd6/action-get-tag@12319896edaa290b27558e34a177804e9b8d077b
Error: Not a tag ref (refs/pull/27/merge)
```

<img width="856" alt="Screenshot 2022-05-30 at 13 37 18" src="https://user-images.githubusercontent.com/1140553/170984474-4665632a-1509-46e2-9073-3abc621809a6.png">

