### PR TITLE
build: move Saturn L2 download to `postinstall`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm run test
-
       - name: Test end-to-end
         uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: npm run build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
         run: npm run test
@@ -96,6 +96,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get tag
         id: tag

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -41,8 +41,7 @@ Repositories:
 
 1. Install the latest LTS version of Node.js
 2. Clone this repository
-3. Run `npm install` to install all dependencies
-4. Run `npm run build:saturn` to download Saturn L2 Node.
+3. Run `npm install` to install all dependencies, including electron components and Saturn L2 Node.
 
 ### Making changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4786,9 +4786,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.2.tgz",
-      "integrity": "sha512-9RzS8wUpxY8dHFJRncro2mEIkCg9Vig1Q0iLu5y3dusEIDKcBRKoW9mVhUeqvZVZgb2SsTEowZBBdBhdL6/+aQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.5.tgz",
+      "integrity": "sha512-gC4kPr/Mf7QbeE5NAo1AC4Zg/SXLnW0ttlyzhVdyB2aErBspWh231UhHLJUlOdaVNqitdbnppdaXjoZHsR5QzQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5175,12 +5175,12 @@
       "integrity": "sha512-tQJBCbXKoKCfkBC143QCqnEtT1s8dNE2V+b/82NF6lxnGO/2Q3a3GSLHtKl3iEDQgdzTf9pH7p418xq2rXbz1Q=="
     },
     "node_modules/electron-store": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.1.tgz",
-      "integrity": "sha512-ZyLvNywiqSpbwC/pp89O/AycVWY/UJIkmtyzF2Bd0Nm/rLmcFc0NTGuLdg6+LE8mS8qsiK5JMoe4PnrecLHH5w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.2.tgz",
+      "integrity": "sha512-9GwUMv51w8ydbkaG7X0HrPlElXLApg63zYy1/VZ/a08ndl0gfm4iCoD3f0E1JvP3V16a+7KxqriCI0c122stiA==",
       "dependencies": {
-        "conf": "^10.0.3",
-        "type-fest": "^1.0.2"
+        "conf": "^10.1.2",
+        "type-fest": "^2.12.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10225,11 +10225,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.1.tgz",
+      "integrity": "sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14255,9 +14255,9 @@
       }
     },
     "electron": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.2.tgz",
-      "integrity": "sha512-9RzS8wUpxY8dHFJRncro2mEIkCg9Vig1Q0iLu5y3dusEIDKcBRKoW9mVhUeqvZVZgb2SsTEowZBBdBhdL6/+aQ==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.5.tgz",
+      "integrity": "sha512-gC4kPr/Mf7QbeE5NAo1AC4Zg/SXLnW0ttlyzhVdyB2aErBspWh231UhHLJUlOdaVNqitdbnppdaXjoZHsR5QzQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",
@@ -14567,12 +14567,12 @@
       "integrity": "sha512-tQJBCbXKoKCfkBC143QCqnEtT1s8dNE2V+b/82NF6lxnGO/2Q3a3GSLHtKl3iEDQgdzTf9pH7p418xq2rXbz1Q=="
     },
     "electron-store": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.1.tgz",
-      "integrity": "sha512-ZyLvNywiqSpbwC/pp89O/AycVWY/UJIkmtyzF2Bd0Nm/rLmcFc0NTGuLdg6+LE8mS8qsiK5JMoe4PnrecLHH5w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.2.tgz",
+      "integrity": "sha512-9GwUMv51w8ydbkaG7X0HrPlElXLApg63zYy1/VZ/a08ndl0gfm4iCoD3f0E1JvP3V16a+7KxqriCI0c122stiA==",
       "requires": {
-        "conf": "^10.0.3",
-        "type-fest": "^1.0.2"
+        "conf": "^10.1.2",
+        "type-fest": "^2.12.2"
       }
     },
     "electron-to-chromium": {
@@ -18264,9 +18264,9 @@
       }
     },
     "type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.1.tgz",
+      "integrity": "sha512-hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "start": "cross-env NODE_ENV=development electron .",
     "lint": "eslint . && tsc -p tsconfig.json && tsc -p renderer/tsconfig.json",
     "lint:fix": "eslint --fix .",
-    "test": "run-s test:*",
+    "test": "run-s build:* && run-s test:*",
     "test:e2e": "xvfb-maybe cross-env NODE_ENV=test playwright test 'test/e2e/.*.test.js'",
-    "postinstall": "run-s install-app-deps",
+    "postinstall": "run-s install-*",
     "install-app-deps": "electron-builder install-app-deps",
-    "clean": "shx rm -rf dist/ build/saturn",
+    "install-saturn": "shx rm -rf build/saturn && node ./build/download-saturn-l2.js",
+    "clean": "shx rm -rf dist/",
     "build": "run-s clean build:*",
     "build:webui": "vite build",
-    "build:saturn": "node ./build/download-saturn-l2.js",
     "package": "shx rm -rf dist/ && run-s build && electron-builder --publish onTag"
   },
   "repository": {

--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -5,11 +5,11 @@ const { request } = require('undici')
 
 const tmp = require('tmp')
 
-if (process.env.CI === 'true') test.setTimeout(120000) // slow ci
-
 // Running test cases one after another
 // More examples: https://playwright.dev/docs/api/class-electron
 test.describe.serial('Application launch', async () => {
+  if (process.env.CI === 'true') test.setTimeout(120_000) // slow CI
+
   /** @type {import('playwright').ElectronApplication} */
   let electronApp
 
@@ -17,6 +17,8 @@ test.describe.serial('Application launch', async () => {
   let mainWindow
 
   test('starts the electron app', async () => {
+    test.slow()
+
     // Launch Electron app against sandbox fake HOME dir
     const userData = tmp.dirSync({ prefix: 'tmp_home_', unsafeCleanup: true }).name
     electronApp = await electron.launch({
@@ -60,7 +62,7 @@ test.describe.serial('Application launch', async () => {
   })
 
   test('wait for Saturn node to get ready', async () => {
-    await mainWindow.waitForFunction(() => window.electron.isSaturnNodeReady(), {}, { timeout: 100 })
+    await mainWindow.waitForFunction(() => window.electron.isSaturnNodeReady(), {})
   })
 
   test('saturn WebUI is available', async () => {


### PR DESCRIPTION
- Rename the script from `build:saturn` to `install-saturn`
- Run this script from `postinstall` hook

This is a follow-up for #38, see also #22