### PR TITLE
feat: tray & app menu item "Check for Updates..."

### DIFF
--- a/main/app-menu.js
+++ b/main/app-menu.js
@@ -1,0 +1,58 @@
+const { Menu, MenuItem, ipcMain } = require('electron')
+const { ipcMainEvents } = require('./ipc')
+
+function setupAppMenu (/** @type {import('./typings').Context} */ ctx) {
+  // Add "Check for updates..." item to the Application menu on MacOS
+  // GitHub issues tracking the work to add this menu item on other platforms:
+  //  - Windows: https://github.com/filecoin-project/filecoin-station/issues/63
+  //  - Linux: https://github.com/filecoin-project/filecoin-station/issues/64
+  if (process.platform !== 'darwin') return
+
+  const menu = Menu.getApplicationMenu()
+  if (!menu) return
+
+  menu.items[0].submenu?.insert(1, new MenuItem({
+    id: 'checkForUpdates',
+    label: 'Check For Updates...',
+    click: () => { ctx.manualCheckForUpdates() }
+  }))
+  menu.items[0].submenu?.insert(2, new MenuItem({
+    id: 'checkingForUpdates',
+    label: 'Checking For Updates',
+    enabled: false,
+    visible: false
+  }))
+
+  Menu.setApplicationMenu(menu)
+  setupIpcEventListeners(menu)
+}
+
+/**
+ * @param {Electron.Menu} appMenu
+ */
+function setupIpcEventListeners (appMenu) {
+  ipcMain.on(ipcMainEvents.UPDATE_CHECK_STARTED, () => {
+    getItemById('checkForUpdates').visible = false
+    getItemById('checkingForUpdates').visible = true
+  })
+
+  ipcMain.on(ipcMainEvents.UPDATE_CHECK_FINISHED, () => {
+    getItemById('checkForUpdates').visible = true
+    getItemById('checkingForUpdates').visible = false
+  })
+
+  /**
+   * Get an item from the main app menu or fail with a useful error message.
+   * @param {string} id
+   * @returns {Electron.MenuItem}
+   */
+  function getItemById (id) {
+    const item = appMenu.getMenuItemById(id)
+    if (!item) throw new Error(`Unknown app menu item id: ${id}`)
+    return item
+  }
+}
+
+module.exports = {
+  setupAppMenu
+}

--- a/main/dialog.js
+++ b/main/dialog.js
@@ -1,0 +1,52 @@
+const { dialog } = require('electron')
+const { IS_MAC } = require('./consts')
+
+module.exports = {
+  showDialogSync
+}
+
+/**
+ * NOTE: always send the buttons in the order [OK, Cancel, ...Actions].
+ * See this post for more interesting information about the topic:
+ * https://medium.muz.li/ok-key-and-cancel-key-which-one-should-be-set-up-on-the-left-4780e86c16eb
+ *
+ * @param {import('electron').MessageBoxSyncOptions & {title: string}} args
+ * @returns
+ */
+function showDialogSync ({
+  title,
+  message,
+  type = 'info',
+  buttons = ['OK', 'Cancel'],
+  ...opts
+}) {
+  const options = {
+    type,
+    buttons,
+    title,
+    message,
+    ...opts
+  }
+
+  if (IS_MAC) {
+    options.message = title
+    options.detail = message
+  }
+
+  const isInverse = !IS_MAC
+
+  if (isInverse) {
+    options.buttons.reverse()
+  }
+
+  if (buttons.length > 1) {
+    options.defaultId = isInverse ? buttons.length - 1 : 0
+    options.cancelId = isInverse ? buttons.length - 2 : 1
+  }
+
+  const selected = dialog.showMessageBoxSync(options)
+
+  return isInverse
+    ? buttons.length - selected - 1
+    : selected
+}

--- a/main/index.js
+++ b/main/index.js
@@ -7,7 +7,8 @@ const setupUI = require('./ui')
 const setupTray = require('./tray')
 const setupUpdater = require('./updater')
 const saturnNode = require('./saturn-node')
-const setupIpc = require('./ipc')
+const { setupIpcMain } = require('./ipc')
+const { setupAppMenu } = require('./app-menu')
 
 const inTest = (process.env.NODE_ENV === 'test')
 
@@ -34,6 +35,7 @@ if (!app.requestSingleInstanceLock() && !inTest) {
 
 /** @type {import('./typings').Context} */
 const ctx = {
+  manualCheckForUpdates: () => { throw new Error('never get here') },
   showUI: () => { throw new Error('never get here') },
   loadWebUIFromDist: serve({ directory: path.resolve(__dirname, '../renderer/dist') })
 }
@@ -49,9 +51,10 @@ async function run () {
   try {
     // Interface
     await setupTray(ctx)
+    await setupAppMenu(ctx)
     await setupUI(ctx)
     await setupUpdater(ctx)
-    await setupIpc()
+    await setupIpcMain()
 
     await saturnNode.setup(ctx)
   } catch (e) {

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -2,7 +2,12 @@ const { ipcMain } = require('electron')
 
 const saturnNode = require('./saturn-node')
 
-module.exports = function () {
+const ipcMainEvents = Object.freeze({
+  UPDATE_CHECK_STARTED: 'station:update-check:started',
+  UPDATE_CHECK_FINISHED: 'station:update-check:finished'
+})
+
+function setupIpcMain () {
   ipcMain.handle('saturn:isRunning', saturnNode.isRunning)
   ipcMain.handle('saturn:isReady', saturnNode.isReady)
   ipcMain.handle('saturn:start', saturnNode.start)
@@ -11,4 +16,9 @@ module.exports = function () {
   ipcMain.handle('saturn:getWebUrl', saturnNode.getWebUrl)
   ipcMain.handle('saturn:getFilAddress', saturnNode.getFilAddress)
   ipcMain.handle('saturn:setFilAddress', (_event, address) => saturnNode.setFilAddress(address))
+}
+
+module.exports = {
+  setupIpcMain,
+  ipcMainEvents
 }

--- a/main/typings.d.ts
+++ b/main/typings.d.ts
@@ -1,4 +1,5 @@
 export interface Context {
   showUI: () => void
   loadWebUIFromDist: import('electron-serve').loadURL
+  manualCheckForUpdates: () => void
 }

--- a/main/updater.js
+++ b/main/updater.js
@@ -1,55 +1,30 @@
-const { BrowserWindow, app, dialog, Notification } = require('electron')
+const { BrowserWindow, app, Notification, shell } = require('electron')
 const { autoUpdater } = require('electron-updater')
-const fs = require('fs')
+const { ipcMain } = require('electron/main')
+const ms = require('ms')
 const log = require('electron-log').scope('updater')
+
+const { showDialogSync } = require('./dialog')
+const { ipcMainEvents } = require('./ipc')
 
 // must be global to avoid gc
 let updateNotification = null
 
+let checkingManually = false
+
+function beforeQuitCleanup () {
+  BrowserWindow.getAllWindows().forEach(w => w.removeAllListeners('close'))
+  app.removeAllListeners('window-all-closed')
+}
+
 function setup (/** @type {import('./typings').Context} */ _ctx) {
   autoUpdater.autoDownload = false // we download manually in 'update-available'
 
-  autoUpdater.on('error', err => log.error('error', err))
-  autoUpdater.on('update-available', async (/* { version, releaseNotes } */) => {
-    try {
-      log.info('update-available, downloading..')
-      await autoUpdater.downloadUpdate()
-      log.info('update-available, downloaded')
-    } catch (err) {
-      log.error('update-available error', err)
-    }
-  })
-  autoUpdater.on('update-not-available', (/* { version } */) => {
-    log.info('update not available')
-  })
-  autoUpdater.on('update-downloaded', ({ version }) => {
-    log.info(`update to ${version} downloaded`)
-    const showUpdateDialog = () => {
-      const opt = dialog.showMessageBoxSync({
-        title: 'Update Filecoin Station',
-        message: `An update to Filecoin Station ${version} is available. Would you like to install it now?`,
-        type: 'info',
-        buttons: ['Later', 'Install now']
-      })
-      if (opt === 1) { // install now
-        setImmediate(async () => {
-          await beforeQuitCleanup()
-          autoUpdater.quitAndInstall()
-        })
-      }
-    }
-    // show unobtrusive notification + dialog on click
-    updateNotification = new Notification({
-      title: 'Filecoin Station Update',
-      body: `An update to Filecoin Station ${version} is available.`
-    })
-    updateNotification.on('click', showUpdateDialog)
-    updateNotification.show()
-  })
-  const beforeQuitCleanup = async () => {
-    BrowserWindow.getAllWindows().forEach(w => w.removeAllListeners('close'))
-    app.removeAllListeners('window-all-closed')
-  }
+  autoUpdater.on('error', onUpdaterError)
+  autoUpdater.on('update-available', onUpdateAvailable)
+  autoUpdater.on('update-not-available', onUpdateNotAvailable)
+  autoUpdater.on('update-downloaded', onUpdateDownloaded)
+
   // built-in updater != electron-updater
   // https://github.com/electron-userland/electron-builder/pull/6395
   require('electron').autoUpdater.on('before-quit-for-update', beforeQuitCleanup)
@@ -57,13 +32,129 @@ function setup (/** @type {import('./typings').Context} */ _ctx) {
 
 module.exports = async function (/** @type {import('./typings').Context} */ ctx) {
   if (['test', 'development'].includes(process.env.NODE_ENV ?? '')) {
-    // skip init in dev if we are not debugging updater
-    if (!fs.existsSync('dev-app-update.yml')) return
+    ctx.manualCheckForUpdates = () => {
+      showDialogSync({
+        title: 'Not available in development',
+        message: 'Yes, you called this function successfully.',
+        type: 'info',
+        buttons: ['Close']
+      })
+    }
+    return
   }
 
   setup(ctx)
+
+  checkForUpdatesInBackground() // async check on startup
+  setInterval(checkForUpdatesInBackground, ms('12h'))
+
+  // enable on-demand check via Tray menu
+  ctx.manualCheckForUpdates = () => {
+    checkingManually = true
+    checkForUpdatesInBackground()
+  }
+}
+
+function checkForUpdatesInBackground () {
+  ipcMain.emit(ipcMainEvents.UPDATE_CHECK_STARTED)
+
   // TODO: replace this with autoUpdater.checkForUpdatesAndNotify()
-  const checkForUpdates = async () => await autoUpdater.checkForUpdates()
-  checkForUpdates() // async check on startup
-  setInterval(checkForUpdates, 43200000) // every 12 hours
+  autoUpdater.checkForUpdates()
+    // We are ignoring errors, they are already handled by our `error` event listener
+    .finally(() => ipcMain.emit(ipcMainEvents.UPDATE_CHECK_FINISHED))
+}
+
+/**
+ * @param {any} err
+ */
+function onUpdaterError (err) {
+  log.error('error', err)
+
+  if (!checkingManually) { return }
+  checkingManually = false
+
+  showDialogSync({
+    title: 'Could not download update',
+    message: 'It was not possible to download the update. Please check your Internet connection and try again.',
+    type: 'error',
+    buttons: ['Close']
+  })
+}
+
+/**
+ * @param {import('electron-updater').UpdateInfo} info
+ */
+function onUpdateAvailable ({ version /*, releaseNotes */ }) {
+  log.info(`Update to version ${version} is available, downloading..`)
+  autoUpdater.downloadUpdate().then(
+    _ => log.info('Update downloaded'),
+    err => log.error('Cannot download the update.', err)
+  )
+
+  if (!checkingManually) { return }
+  // do not toggle checkingManually off here so we can show a dialog once the download
+  // is finished.
+
+  const buttonIx = showDialogSync({
+    title: 'Update available',
+    message: `A new version ${version} of Filecoin Station is available. The download will begin shortly in the background.`,
+    type: 'info',
+    buttons: ['Close', 'Show Release Notes']
+  })
+
+  if (buttonIx === 1) {
+    shell.openExternal(`https://github.com/filecoin-project/filecoin-station/releases/v${version}`)
+  }
+}
+
+/**
+ * @param {import('electron-updater').UpdateInfo} info
+ */
+function onUpdateNotAvailable ({ version }) {
+  log.info(`update not available from version ${version}`)
+
+  if (!checkingManually) { return }
+  checkingManually = false
+
+  showDialogSync({
+    title: 'Update not available',
+    message: `You are on the latest version of Filecoin Station (${version}).`,
+    type: 'info',
+    buttons: ['Close']
+  })
+}
+
+/**
+ * @param {import('electron-updater').UpdateDownloadedEvent} event
+ */
+function onUpdateDownloaded ({ version /*, releaseNotes */ }) {
+  log.info(`update to ${version} downloaded`)
+
+  const showUpdateDialog = () => {
+    const buttonIx = showDialogSync({
+      title: 'Update Filecoin Station',
+      message: `An update to Filecoin Station ${version} is available. Would you like to install it now?`,
+      type: 'info',
+      buttons: ['Later', 'Install now']
+    })
+    if (buttonIx === 1) { // install now
+      setImmediate(async () => {
+        beforeQuitCleanup()
+        autoUpdater.quitAndInstall()
+      })
+    }
+  }
+
+  if (checkingManually) {
+    // when checking manually, show the dialog immediately
+    showUpdateDialog()
+  } else {
+    // show unobtrusive notification + dialog on click
+    updateNotification = new Notification({
+      title: 'Filecoin Station Update',
+      body: `An update to Filecoin Station ${version} is available.`
+    })
+    updateNotification.on('click', showUpdateDialog)
+    updateNotification.show()
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "electron-store": "^8.0.1",
         "electron-updater": "^5.0.1",
         "execa": "^5.1.1",
+        "ms": "^2.1.3",
         "prettier": "^2.7.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -4347,6 +4348,11 @@
         }
       }
     },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -8155,9 +8161,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multiformats": {
       "version": "9.7.0",
@@ -13962,6 +13968,13 @@
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decompress-response": {
@@ -16734,9 +16747,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "multiformats": {
       "version": "9.7.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "electron-store": "^8.0.1",
     "electron-updater": "^5.0.1",
     "execa": "^5.1.1",
+    "ms": "^2.1.3",
     "prettier": "^2.7.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
Add "Check for Updates..." to the Tray menu. On macOS, add this item to the Application menu too. While the check is running, replace "Check for Updates" with a disabled item "Checking for Updates".

See https://github.com/filecoin-project/filecoin-station/issues/53

The implementation is heavily inspired by IPFS Desktop:
- [src/auto-updater/index.js](https://github.com/ipfs/ipfs-desktop/blob/b269cde5231915d2930eefba55b706012843a155/src/auto-updater/index.js)
- [src/tray.js](https://github.com/ipfs/ipfs-desktop/blob/b269cde5231915d2930eefba55b706012843a155/src/tray.js)

### Out of scope

- Reworking the OS-level notification
- Showing a banner at the top of the web UI when an update is ready

### Screenshots

A new macOS application menu item:

<img width="264" alt="Screenshot 2022-07-27 at 14 48 56" src="https://user-images.githubusercontent.com/1140553/181251929-f6809950-00d1-4eae-ac9c-88f0caa59c38.png">

While checking for updates:

<img width="262" alt="Screenshot 2022-07-27 at 14 49 06" src="https://user-images.githubusercontent.com/1140553/181252035-ac722fca-25c9-4cd3-a61a-92dee4985571.png">

A new Tray menu item:

<img width="233" alt="Screenshot 2022-07-27 at 14 50 35" src="https://user-images.githubusercontent.com/1140553/181252104-9549a12b-ae41-49ec-897e-eb8bb838553c.png">

While checking for updates:

<img width="218" alt="Screenshot 2022-07-27 at 14 50 41" src="https://user-images.githubusercontent.com/1140553/181252150-bed56031-1513-4f78-8011-237ac3815d93.png">

Various dialogs shown by the app:

<img width="757" alt="Screenshot 2022-07-27 at 14 49 33" src="https://user-images.githubusercontent.com/1140553/181252217-5d764748-b726-47de-9722-3dc543763b0d.png">

<img width="327" alt="Screenshot 2022-07-27 at 14 51 43" src="https://user-images.githubusercontent.com/1140553/181252280-0b80bbbf-9df2-4d45-a456-380b21906391.png">
<img width="328" alt="Screenshot 2022-07-27 at 14 51 56" src="https://user-images.githubusercontent.com/1140553/181252288-eddea2f7-c23e-41fe-a306-631847d6ee0c.png">
<img width="312" alt="Screenshot 2022-07-27 at 14 52 05" src="https://user-images.githubusercontent.com/1140553/181252292-71c8da42-b5ae-420a-a421-6c7f52e0c139.png">

The annoying notification we should remove later:

<img width="357" alt="Screenshot 2022-07-27 at 14 51 24" src="https://user-images.githubusercontent.com/1140553/181252474-866d3a98-64b1-4009-8a1a-cd0dd7ab425a.png">
