### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    reviewers:
+      - "bajtos"
+      - "juliangruber"


### PR DESCRIPTION
Enable GitHub's Dependabot integration so that we don't have to update `package-lock.json` manually. (E.g. #82)

For the initial iteration, I am using the default versioning strategy. I think that means _increase: Always increase the version requirement to match the new version._ We can easily tweak the strategy later as needed.

I propose running Dependabot only once a week to avoid too much noise in our git commit history.

See GitHub docs for more details:
- [Keeping your dependencies updated automatically with Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates)
- [Configuration options for the dependabot.yml file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)