### PR TITLE
build: tweak Dependabot commit messages again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
     commit-message:
       prefix: "deps"
       prefix-development: "deps(dev)"
-      include: "scope"
     reviewers:
       - "bajtos"
       - "juliangruber"


### PR DESCRIPTION
Another attempt to get sensible commit messages & PR titles - see https://github.com/filecoin-project/filecoin-station/pull/98#issuecomment-1237031510

I think I have originally misunderstood what `include: "scope"` means.  Apparently, the scope is "deps" or "deps-dev" for npm. We don't want such scope string in our commit messages.

In this commit, I am removing `include` config for commit messages.

See also the Dependabot code building git commit messages:
https://github.com/dependabot/dependabot-core/blob/588aa78ce05b60315e699951bb14935fa0d49230/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb#L74-L82
