### PR TITLE
chore: enable strict mode in JS files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,14 @@
   "overrides": [
     {
       "files": ["build/**/*.js", "main/**/*.js", "test/**/*.js", "*.js"],
+      "parserOptions": {
+        "sourceType": "commonjs"
+      },
+      "env": {
+        "node": true
+      },
       "rules": {
+        "strict": ["error", "global"],
         "@typescript-eslint/no-var-requires": "off"
       }
     },

--- a/build/notarize-macos.js
+++ b/build/notarize-macos.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { notarize } = require('electron-notarize')
 
 const isSet = (/** @type {string | undefined} */ value) => value && value !== 'false'

--- a/main/app-menu.js
+++ b/main/app-menu.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('node:fs/promises')
 const { Menu, MenuItem, ipcMain, dialog, BrowserWindow } = require('electron')
 const { ipcMainEvents } = require('./ipc')

--- a/main/consts.js
+++ b/main/consts.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const os = require('os')
 const packageJson = require('../package.json')
 const path = require('path')

--- a/main/dialog.js
+++ b/main/dialog.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { dialog } = require('electron')
 const { IS_MAC } = require('./consts')
 

--- a/main/index.js
+++ b/main/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { app, dialog } = require('electron')
 const log = require('electron-log')
 const serve = require('electron-serve')

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { ipcMain } = require('electron')
 
 const saturnNode = require('./saturn-node')

--- a/main/preload.js
+++ b/main/preload.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('electron', {

--- a/main/store.js
+++ b/main/store.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const electron = require('electron')
 const Store = require('electron-store')
 

--- a/main/test/smoke.test.js
+++ b/main/test/smoke.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const assert = require('node:assert')
 
 describe('smoke test', function () {

--- a/main/tray.js
+++ b/main/tray.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { Menu, Tray, shell, app, ipcMain } = require('electron')
 const path = require('path')
 const { IS_MAC, STATION_VERSION } = require('./consts')

--- a/main/ui.js
+++ b/main/ui.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const path = require('path')
 
 const { BrowserWindow, app, screen } = require('electron')

--- a/main/updater.js
+++ b/main/updater.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { BrowserWindow, app, Notification, shell } = require('electron')
 const { autoUpdater } = require('electron-updater')
 const { ipcMain } = require('electron/main')

--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { _electron: electron } = require('playwright')
 const { test, expect } = require('@playwright/test')
 const path = require('path')

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { defineConfig } = require('vite')
 const react = require('@vitejs/plugin-react').default
 const path = require('node:path')


### PR DESCRIPTION
- Configure eslint to require `use strict` in all JS files
- Add missing `use strict` lines where needed
