### PR TITLE
test: fix e2e test timing out on Windows

### DIFF
--- a/test/e2e/app-launch.e2e.test.js
+++ b/test/e2e/app-launch.e2e.test.js
@@ -31,7 +31,8 @@ test.describe.serial('Application launch', async () => {
         ...process.env,
         NODE_ENV: 'test',
         HOME: userData
-      }
+      },
+      timeout: 30000 * TIMEOUT_MULTIPLIER
     })
 
     // Get the first window that the app opens, wait if necessary.


### PR DESCRIPTION
Allow more time for `electron.launch` to complete when running on CI.

The goal is to fix the following CI failure:
https://github.com/filecoin-project/filecoin-station/runs/8250938538?check_suite_focus=true

<img width="787" alt="Screenshot 2022-09-08 at 16 11 09" src="https://user-images.githubusercontent.com/1140553/189144449-b462a518-fef2-4d34-8a2c-fa758f049675.png">
