### PR TITLE
Add Plausible. Closes #80

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Filecoin Station</title>
+    <script defer data-domain="app.station.filecoin.io" src="https://plausible.io/js/plausible.local.js"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Closes #80.

- [x] Set up Plausible project for `app.station.filecoin.io`
- [x] Invite @patrickwoodhead and @bajtos as admins
- [x] Integrate Plausible script

@bajtos documented these events to be captured, which I think are already covered by default:

> Modify Station UI to report the following events
> - a user starts the app (the onboarding flow)

This is a pageview on `/` or `/onboarding` or whatever we want to call the route, as long as it isn't the same URL as the dashboard. In the current version, `/` is onboarding and `/saturn` is the dashboard.

> - the user closes the app at the screen “Enter FIL”

Plausible lists "exit pages", as long as the "Enter FIL" screen has its own URL this will be taken care of already.