### PR TITLE
fix: move `undici` to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.3.0",
-        "tar-fs": "^2.1.1"
+        "tar-fs": "^2.1.1",
+        "undici": "^5.10.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.25.2",
@@ -65,7 +66,6 @@
         "tailwindcss": "^3.1.8",
         "tmp": "^0.2.1",
         "typescript": "^4.8.3",
-        "undici": "^5.10.0",
         "vite": "^3.1.2",
         "vitest": "^0.23.4",
         "xvfb-maybe": "^0.2.1"
@@ -13021,7 +13021,6 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
       "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
-      "dev": true,
       "engines": {
         "node": ">=12.18"
       }
@@ -23530,8 +23529,7 @@
     "undici": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
-      "dev": true
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",
-    "tar-fs": "^2.1.1"
+    "tar-fs": "^2.1.1",
+    "undici": "^5.10.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.25.2",
@@ -94,7 +95,6 @@
     "tailwindcss": "^3.1.8",
     "tmp": "^0.2.1",
     "typescript": "^4.8.3",
-    "undici": "^5.10.0",
     "vite": "^3.1.2",
     "vitest": "^0.23.4",
     "xvfb-maybe": "^0.2.1"


### PR DESCRIPTION
Before this change, `undici` was a dev-dependency. It was not packaged into the application. As a result, the app was crashing at startup.

This fixes the regression introduced by #136