### PR TITLE
lint: remove insufficient `"sort-import"` and `"require-sort"`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,15 +5,12 @@
       "standard"
   ],
   "plugins": [
-    "@typescript-eslint",
-    "eslint-plugin-require-sort"
+    "@typescript-eslint"
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": ["error", {
       "argsIgnorePattern": "^_"
-    }],
-    "sort-imports": ["error"],
-    "require-sort/require-sort": ["error"]
+    }]
   },
   "ignorePatterns": [
     "assets/",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-require-sort": "^1.3.0",
         "eslint-plugin-standard": "^5.0.0",
         "gunzip-maybe": "^1.4.2",
         "jsdom": "^20.0.0",
@@ -7044,12 +7043,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/eslint-plugin-require-sort": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-require-sort/-/eslint-plugin-require-sort-1.3.0.tgz",
-      "integrity": "sha512-uGyXChANR0kO9SWqZDrZquyVfYQCydovKGjM7zCo+rZE2l3eoWXkNDVZC4JaHYANJ9m5fJ5QE/5kcWHGJLofSQ==",
-      "dev": true
     },
     "node_modules/eslint-plugin-standard": {
       "version": "5.0.0",
@@ -19211,12 +19204,6 @@
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
       "requires": {}
-    },
-    "eslint-plugin-require-sort": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-require-sort/-/eslint-plugin-require-sort-1.3.0.tgz",
-      "integrity": "sha512-uGyXChANR0kO9SWqZDrZquyVfYQCydovKGjM7zCo+rZE2l3eoWXkNDVZC4JaHYANJ9m5fJ5QE/5kcWHGJLofSQ==",
-      "dev": true
     },
     "eslint-plugin-standard": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-require-sort": "^1.3.0",
     "eslint-plugin-standard": "^5.0.0",
     "gunzip-maybe": "^1.4.2",
     "jsdom": "^20.0.0",


### PR DESCRIPTION
`eslint --fix` was unable to format these unfortunately.