### PR TITLE
build: create Sentry releases & upload source maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Check out Git repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install Node.js
         uses: actions/setup-node@v2
@@ -50,6 +52,28 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Install Sentry CLI
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli --version
+
+      - name: Configure SENTRY env vars
+        run:
+          node ./build/configure-sentry.js >> $GITHUB_ENV
+
+      - name: Create Sentry release
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: protocol-labs-ip
+          SENTRY_PROJECT: filecoin-station
+        run: |
+          sentry-cli releases new "${{ env.SENTRY_VERSION }}"
+          sentry-cli releases set-commits "${{ env.SENTRY_VERSION }}" --local --ignore-missing
+          sentry-cli releases files "${{ env.SENTRY_VERSION }}" upload-sourcemaps ./renderer/dist/assets
+          sentry-cli releases deploys "${{ env.SENTRY_VERSION }}" new -e "${{ env.SENTRY_ENV }}"
 
       - name: Test backend
         run: npm run test:backend
@@ -148,4 +172,3 @@ jobs:
 
       - name: Show Cache
         run: du -sh ${{ github.workspace }}/.cache/ && ls -l ${{ github.workspace }}/.cache/
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  finalize-sentry-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+
+      - name: Configure SENTRY env vars
+        run:
+          node ./build/configure-sentry.js >> $GITHUB_ENV
+
+      - name: Install Sentry CLI
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli --version
+
+      - name: Finalize the Sentry release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: protocol-labs-ip
+          SENTRY_PROJECT: filecoin-station
+        run: sentry-cli releases finalize "${{ env.SENTRY_VERSION }}"

--- a/build/before-pack.js
+++ b/build/before-pack.js
@@ -12,7 +12,14 @@ exports.default = async function ({ packager }) {
   // the packaged version of `package.json`.
   // Learn more in the docs:
   // https://www.electron.build/configuration/configuration.html#Configuration-extraMetadata
-  const extraMetadata = packager.config.extraMetadata
-  extraMetadata.buildTag = process.env.GITHUB_REF_TYPE === 'tag' ? process.env.GITHUB_REF_NAME : null
-  extraMetadata.buildNumber = process.env.GITHUB_RUN_NUMBER ?? '1-dev'
+  Object.assign(packager.config.extraMetadata, getGitHubBuildMetadata())
 }
+
+function getGitHubBuildMetadata () {
+  return {
+    buildTag: process.env.GITHUB_REF_TYPE === 'tag' ? process.env.GITHUB_REF_NAME : null,
+    buildNumber: process.env.GITHUB_RUN_NUMBER ?? '1-dev'
+  }
+}
+
+exports.getGitHubBuildMetadata = getGitHubBuildMetadata

--- a/build/configure-sentry.js
+++ b/build/configure-sentry.js
@@ -1,0 +1,14 @@
+// This is called by GitHub Actions workflow to determine the build version to report to Sentry
+
+'use strict'
+
+const { getGitHubBuildMetadata } = require('./before-pack')
+const { getBuildVersion } = require('../main/build-version')
+const packageJson = require('../package.json')
+
+const { buildNumber, buildTag } = getGitHubBuildMetadata()
+const { version } = packageJson
+
+const buildVersion = getBuildVersion({ version, buildNumber, buildTag })
+console.log('SENTRY_VERSION=%s', buildVersion)
+console.log('SENTRY_ENV=%s', buildTag ? 'production' : 'development')

--- a/main/build-version.js
+++ b/main/build-version.js
@@ -1,0 +1,31 @@
+// This code is shared between Electron main (backend) and GitHub Actions workflow
+// We can use vanilla Node.js APIs only. In particular, we CANNOT use `require('electron)`
+
+'use strict'
+
+/**
+ * @param {object} args
+ * @param {string} args.version Semantic version number from package.json, e.g. `0.5.0`
+ * @param {string | null} [args.buildTag] Git tag used to build this version.  `undefined` for
+ *   non-release builds.
+ * @param {string | null} [args.buildNumber] CI build number of the workflow run that created this version.
+ * @returns {string} A build version in one of the following formats:
+ *  - `x.y.z` for release builds, e.g. `0.5.0`.
+ *  - `x.y.z.N` for CI builds, where N is the build number, e.g. `0.5.0.4238`.
+ *  - `x.y.z.1-dev` in all other cases (typically a local dev build), e.g. `0.5.0.1-dev`.
+ */
+function getBuildVersion ({ version, buildTag, buildNumber }) {
+  // A release build produced by GitHub Actions CI
+  if (buildTag === `v${version}`) return version
+
+  // A non-release build produced by GitHub Actions CI
+  if (buildNumber) return `${version}.${buildNumber}`
+
+  // A local build.
+  // TODO: can we use Git commit SHA?
+  return `${version}.1-dev`
+}
+
+module.exports = {
+  getBuildVersion
+}

--- a/main/consts.js
+++ b/main/consts.js
@@ -5,13 +5,15 @@ const os = require('os')
 const packageJson = require('../package.json')
 const path = require('path')
 
+const { getBuildVersion } = require('./build-version')
+
 module.exports = Object.freeze({
   CACHE_HOME: getCacheHome(),
   IS_MAC: os.platform() === 'darwin',
   IS_WIN: os.platform() === 'win32',
   IS_APPIMAGE: typeof process.env.APPIMAGE !== 'undefined',
   STATION_VERSION: packageJson.version,
-  BUILD_VERSION: getBuildVersion(),
+  BUILD_VERSION: getBuildVersion(packageJson),
 
   ELECTRON_VERSION: process.versions.electron
 })
@@ -34,17 +36,4 @@ function getCacheHome () {
     default:
       throw new Error(`Unsupported platform: ${platform}`)
   }
-}
-
-function getBuildVersion () {
-  const { version, buildTag, buildNumber } = packageJson
-  // A release build produced by GitHub Actions CI
-  if (buildTag === `v${version}`) return version
-
-  // A non-release build produced by GitHub Actions CI
-  if (buildNumber) return `${packageJson.version}.${packageJson.buildNumber}`
-
-  // A local build.
-  // TODO: can we use Git commit SHA?
-  return `${packageJson.version}.1-dev`
 }


### PR DESCRIPTION
Add new CI/CD build steps to create Sentry Release entry and upload source maps.

See https://github.com/filecoin-project/filecoin-station/issues/78

Sentry docs: https://docs.sentry.io/product/cli/releases/

Initially, I started with `getsentry/action-release@v1`. Unfortunately, it does not allow us to connect custom version numbers (e.g. `0.6.0.2134`) with git commit SHAs. Thus I reworked our integration to use directly `sentry-cli`.