### PR TITLE
add: filAddress check to onboarding

### DIFF
--- a/renderer/src/pages/Onboarding.tsx
+++ b/renderer/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { getOnboardingCompleted, setOnboardingCompleted } from '../lib/station-config'
+import { getFilAddress, getOnboardingCompleted, setOnboardingCompleted } from '../lib/station-config'
 import Onboarding from '../components/Onboarding'
 import { ReactComponent as StationLogoLight } from '../assets/img/station-logo-light.svg'
 
@@ -20,20 +20,24 @@ const OnboardingPage = (): JSX.Element => {
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [isOnboardingCompleted, setIsOnboardingCompleted] = useState<boolean|null>()
+  const [filAddress, setFilAddress] = useState<string|null>()
 
   useEffect(() => {
     (async () => {
       await sleep(2000)
+      setFilAddress(await getFilAddress())
       setIsOnboardingCompleted(await getOnboardingCompleted())
       setIsLoading(false)
     })()
   }, [])
 
   useEffect(() => {
-    if (isOnboardingCompleted) {
+    if (isOnboardingCompleted && !filAddress) {
       navigate('/wallet', { replace: true })
+    } else if (filAddress) {
+      navigate('/dashboard', { replace: true })
     }
-  }, [isOnboardingCompleted, navigate])
+  }, [filAddress, isOnboardingCompleted, navigate])
 
   const onFinishOnboarding = useCallback(async () => {
     setIsOnboardingCompleted(true)

--- a/renderer/src/test/onboarding.test.tsx
+++ b/renderer/src/test/onboarding.test.tsx
@@ -8,20 +8,24 @@ import { BrowserRouter } from 'react-router-dom'
 const mockedUsedNavigate = vi.fn()
 
 describe('Welcome page test', () => {
-  describe('User have not completed the onboarding', () => {
-    vi.mock('../lib/station-config', () => {
-      return {
-        setOnboardingCompleted: () => Promise.resolve(undefined),
-        getOnboardingCompleted: (status: boolean) => Promise.resolve(false)
-      }
-    })
+  describe('User has not completed the onboarding', () => {
+    beforeAll(() => {
+      vi.clearAllMocks()
+      vi.mock('../lib/station-config', () => {
+        return {
+          setOnboardingCompleted: () => Promise.resolve(undefined),
+          getOnboardingCompleted: (status: boolean) => Promise.resolve(false),
+          getFilAddress: () => Promise.resolve(undefined)
+        }
+      })
 
-    vi.mock('react-router-dom', async () => {
-      const router: typeof import('react-router-dom') = await vi.importActual('react-router-dom')
-      return {
-        ...router,
-        useNavigate: () => mockedUsedNavigate
-      }
+      vi.mock('react-router-dom', async () => {
+        const router: typeof import('react-router-dom') = await vi.importActual('react-router-dom')
+        return {
+          ...router,
+          useNavigate: () => mockedUsedNavigate
+        }
+      })
     })
 
     beforeEach(() => {
@@ -59,28 +63,56 @@ describe('Welcome page test', () => {
     })
   })
 
-  describe('User have completed the onboarding previously', () => {
-    vi.mock('../lib/station-config', () => {
-      return {
-        getOnboardingCompleted: (status: boolean) => Promise.resolve(true)
-      }
-    })
-
-    vi.mock('react-router-dom', async () => {
-      const router: typeof import('react-router-dom') = await vi.importActual('react-router-dom')
-      return {
-        ...router,
-        useNavigate: () => mockedUsedNavigate
-      }
-    })
-
+  describe('User has completed the onboarding previously', () => {
     beforeAll(() => {
+      vi.clearAllMocks()
+      vi.mock('../lib/station-config', () => {
+        return {
+          setOnboardingCompleted: () => Promise.resolve(undefined),
+          getOnboardingCompleted: (status: boolean) => Promise.resolve(true),
+          getFilAddress: () => Promise.resolve(undefined)
+        }
+      })
+
+      vi.mock('react-router-dom', async () => {
+        const router: typeof import('react-router-dom') = await vi.importActual('react-router-dom')
+        return {
+          ...router,
+          useNavigate: () => mockedUsedNavigate
+        }
+      })
+    })
+
+    beforeEach(() => {
       render(<BrowserRouter> <Onboarding /></BrowserRouter >)
     })
 
     test('redirects to dashboard directly if user is onboarded', async () => {
       await waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledTimes(1), { timeout: 3000 })
       await waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledWith('/wallet', { replace: true }), { timeout: 3000 })
+    })
+  })
+
+  describe('User has completed the onboarding and set up wallet previously', () => {
+    beforeAll(() => {
+      vi.clearAllMocks()
+      vi.mock('../lib/station-config', () => {
+        return {
+          setOnboardingCompleted: () => Promise.resolve(undefined),
+          getOnboardingCompleted: (status: boolean) => Promise.resolve(false),
+          getFilAddress: () => Promise.resolve('f16m5slrkc6zumruuhdzn557a5sdkbkiellron4qa')
+        }
+      })
+    })
+
+    beforeEach(() => {
+      vi.resetAllMocks()
+      render(<BrowserRouter> <Onboarding /></BrowserRouter >)
+    })
+
+    test('redirects to dashboard directly if user is onboarded', async () => {
+      expect(mockedUsedNavigate).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledWith('/dashboard', { replace: true }), { timeout: 3000 })
     })
   })
 })


### PR DESCRIPTION
This PRs adds to the Onboarding page (entrypoint) the capacity to route the user to `WalletConfig` or `Dashboard` based on previous wallet configuration. 
if the user has already seen the onboarding and configured the wallet, will be redirected to the dashboard page. 