### PR TITLE
Fix run backend tests in CI. Closes #167

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Test backend
         run: npm run test:backend
 
+      - name: Test ui
+        run: npm run test:ui
+
       - name: Test end-to-end
         uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
+      - name: Test backend
+        run: npm run test:backend
+
+      - name: Test end-to-end
         uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
         with:
           working-directory: ${{ github.workspace }}
-          run: npm test
+          run: npm run test:e2e
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test end-to-end
+      - name: Test
         uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
         with:
           working-directory: ${{ github.workspace }}
-          run: npm run test:e2e
+          run: npm test
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Test backend
         run: npm run test:backend
 
-      - name: Test ui
-        run: npm run test:ui
-
       - name: Test end-to-end
         uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # v1.6
         with:


### PR DESCRIPTION
Closes #167

<del>`npm run test:ui` currently fails, so only adding `npm run test:backend` to CI</del> UI tests have been fixed and added in https://github.com/filecoin-project/filecoin-station/pull/178